### PR TITLE
libtorrent: Add scanf cache vector

### DIFF
--- a/libtorrent/rak/udp_tracker_info.h
+++ b/libtorrent/rak/udp_tracker_info.h
@@ -1,0 +1,68 @@
+#ifndef RAK_UDP_TRACKER_INFO_H
+#define RAK_UDP_TRACKER_INFO_H
+
+#include <string>
+#include <vector>
+
+namespace rak {
+
+class udp_tracker_info {
+public:
+  bool equals (const std::string u) { return url.compare(u) == 0; }
+
+  void set (const std::string u, const char* h, const int p) {
+    url = u;
+    hostname.assign(h);
+    port = p;
+    broken = false;
+  }
+  void set_broken() { broken = true; }
+  bool get_broken() { return broken; }
+
+  std::string get_url() { return url; }
+  std::string get_hostname() { return hostname; }
+  int get_port() { return port; }
+
+private:
+  bool broken;
+  std::string url;
+  std::string hostname;
+  int port;
+};
+
+class udp_tracker_vector : public std::vector<udp_tracker_info> {
+public:
+  udp_tracker_info get_info(const std::string url) {
+    for (size_t i=0; i<size(); i++) {
+      if (at(i).equals(url)) {
+        return at(i);
+      }
+    }
+    return create_info(url);
+  }
+
+private:
+  typedef std::vector<udp_tracker_info>       base_type;
+  typedef typename base_type::reference       reference;
+  using base_type::size;
+  using base_type::at;
+
+  udp_tracker_info create_info(const std::string url) {
+    char hostname[1024] = {0};
+    int port;
+    udp_tracker_info new_info;
+
+    if (sscanf(url.c_str(), "udp://%1023[^:]:%i/announce", &hostname, &port) == 2 && hostname[0] != '\0' && port > 0 && port < (1 << 16)) {
+      new_info.set(url, hostname, port);
+      base_type::push_back(new_info);
+      return new_info;
+    }
+
+    new_info.set_broken();
+    return new_info;
+  }
+};
+
+}
+
+#endif

--- a/libtorrent/src/globals.cc
+++ b/libtorrent/src/globals.cc
@@ -43,5 +43,6 @@ namespace torrent {
 
 LIBTORRENT_EXPORT rak::priority_queue_default taskScheduler;
 LIBTORRENT_EXPORT rak::timer                  cachedTime;
+LIBTORRENT_EXPORT rak::udp_tracker_vector     udpTrackerInfo;
 
 }

--- a/libtorrent/src/globals.h
+++ b/libtorrent/src/globals.h
@@ -39,11 +39,13 @@
 
 #include <rak/timer.h>
 #include <rak/priority_queue_default.h>
+#include <rak/udp_tracker_info.h>
 
 namespace torrent {
 
 extern rak::priority_queue_default taskScheduler;
 extern rak::timer                  cachedTime;
+extern rak::udp_tracker_vector     udpTrackerInfo;
 
 }
 

--- a/libtorrent/src/torrent/tracker_list.cc
+++ b/libtorrent/src/torrent/tracker_list.cc
@@ -198,7 +198,12 @@ TrackerList::insert_url(unsigned int group, const std::string& url, bool extra_t
     tracker = new TrackerHttp(this, url, flags);
 
   } else if (std::strncmp("udp://", url.c_str(), 6) == 0) {
-    tracker = new TrackerUdp(this, url, flags);
+    rak::udp_tracker_info udpInfo = udpTrackerInfo.get_info(url);
+    if (udpInfo.get_broken()) {
+       LT_LOG_TRACKER(INFO, "skipped broken tracker (url:%s)", url.c_str());
+       return;
+    }    
+    tracker = new TrackerUdp(this, udpInfo, flags);
 
   } else if (std::strncmp("dht://", url.c_str(), 6) == 0 && TrackerDht::is_allowed()) {
     tracker = new TrackerDht(this, url, flags);

--- a/libtorrent/src/tracker/tracker_udp.h
+++ b/libtorrent/src/tracker/tracker_udp.h
@@ -60,7 +60,7 @@ public:
 
   static const uint64_t magic_connection_id = 0x0000041727101980ll;
 
-  TrackerUdp(TrackerList* parent, const std::string& url, int flags);
+  TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int flags);
   ~TrackerUdp();
   
   const char*         type_name() const { return "tracker_udp"; }
@@ -94,10 +94,11 @@ private:
   bool                process_error_output();
 
   bool                parse_udp_url(const std::string& url, hostname_type& hostname, int& port) const;
-  resolver_type*      make_resolver_slot(const hostname_type& hostname);
+  resolver_type*      make_resolver_slot(const char* hostname);
 
   rak::socket_address m_connectAddress;
   int                 m_port;
+  std::string         m_hostname;
 
   int                 m_sendState;
 


### PR DESCRIPTION
This commit creates a new udp tracker info vector to parse the hostname and port for UDP trackers.

It avoids calling sscanf tens of thousands of times, which may result in performance issues. Worse case scenario, it can also crash the software.

It's often the case where multiple torrents will have the same UDP trackers. If this is the case, the hostname and port will be recalled from the vector to avoid repetitive lookups. This improves the performance when initializing torrents.

The hostname and port data is then passed to the UDP tracker class on initialization.