### PR TITLE
libtorrent: Simplify updating queue entries

### DIFF
--- a/libtorrent/rak/priority_queue.h
+++ b/libtorrent/rak/priority_queue.h
@@ -73,6 +73,10 @@ public:
     std::pop_heap(begin(), end(), m_compare);
     base_type::pop_back();
   }
+  
+  void update() {
+    std::make_heap(begin(), end(), m_compare);
+  }
 
   void push(const value_type& value) {
     base_type::push_back(value);
@@ -95,12 +99,8 @@ public:
     return true;
   }
 
-  // Removes 'itr' from the queue. This assumes 'itr' has been
-  // modified such that it has a higher priority than any other
-  // element in the queue.
+  // Removes 'itr' from the queue.
   void erase(iterator itr) {
-//     std::push_heap(begin(), ++itr, m_compare);
-//     pop();
     base_type::erase(itr);
     std::make_heap(begin(), end(), m_compare);
   }

--- a/libtorrent/rak/priority_queue_default.h
+++ b/libtorrent/rak/priority_queue_default.h
@@ -127,7 +127,7 @@ priority_queue_erase(priority_queue_default* queue, priority_item* item) {
   if (!item->is_valid())
     throw torrent::internal_error("priority_queue_erase(...) called on an invalid item.");
 
-  // Clear time before erasing to force it to the top.
+  // Unqueue it before erasing.
   item->clear_time();
   
   if (!queue->erase(item))
@@ -135,6 +135,26 @@ priority_queue_erase(priority_queue_default* queue, priority_item* item) {
 
   if (queue->find(item) != queue->end())
     throw torrent::internal_error("priority_queue_erase(...) item still in queue.");
+}
+
+inline void
+priority_queue_upsert(priority_queue_default* queue, priority_item* item, timer t) {
+  if (t == timer())
+    throw torrent::internal_error("priority_queue_insert(...) received a bad timer.");
+
+  if (!item->is_valid())
+    throw torrent::internal_error("priority_queue_insert(...) called on an invalid item.");
+
+  if (queue->find(item) == queue->end()) {
+    if (item->is_queued())
+      throw torrent::internal_error("priority_queue_upsert(...) cannot insert an already queued item.");
+    item->set_time(t);
+    queue->push(item);
+
+  } else {
+    item->set_time(t);
+    queue->update();
+  }
 }
 
 }

--- a/libtorrent/src/data/hash_torrent.cc
+++ b/libtorrent/src/data/hash_torrent.cc
@@ -214,8 +214,7 @@ HashTorrent::queue(bool quick) {
 
       LT_LOG_THIS(INFO, "Completed (error): position:%u try_quick:%u errno:%i msg:'%s'.",
                   m_position, quick, m_errno, handle.error_number().c_str());
-      rak::priority_queue_erase(&taskScheduler, &m_delayChecked);
-      rak::priority_queue_insert(&taskScheduler, &m_delayChecked, cachedTime);
+      rak::priority_queue_upsert(&taskScheduler, &m_delayChecked, cachedTime);
       return;
     }
 
@@ -237,10 +236,9 @@ HashTorrent::queue(bool quick) {
   if (m_outstanding == 0) {
     LT_LOG_THIS(INFO, "Completed (normal): position:%u try_quick:%u.", m_position, quick);
 
-    // Erase the scheduled item just to make sure that if hashing is
+    // Update the scheduled item just to make sure that if hashing is
     // started again during the delay it won't cause an exception.
-    rak::priority_queue_erase(&taskScheduler, &m_delayChecked);
-    rak::priority_queue_insert(&taskScheduler, &m_delayChecked, cachedTime);
+    rak::priority_queue_upsert(&taskScheduler, &m_delayChecked, cachedTime);
    }
 }
 

--- a/libtorrent/src/download/download_main.cc
+++ b/libtorrent/src/download/download_main.cc
@@ -349,8 +349,7 @@ DownloadMain::receive_tracker_success() {
   if (!info()->is_active())
     return;
 
-  priority_queue_erase(&taskScheduler, &m_taskTrackerRequest);
-  priority_queue_insert(&taskScheduler, &m_taskTrackerRequest, (cachedTime + rak::timer::from_seconds(10)).round_seconds());
+  priority_queue_upsert(&taskScheduler, &m_taskTrackerRequest, (cachedTime + rak::timer::from_seconds(10)).round_seconds());
 }
 
 void

--- a/libtorrent/src/download/download_wrapper.cc
+++ b/libtorrent/src/download/download_wrapper.cc
@@ -225,9 +225,8 @@ DownloadWrapper::receive_hash_done(ChunkHandle handle, const char* hash) {
         finished_download();
 
       } else if (was_partial && data()->wanted_chunks() == 0) {
-        priority_queue_erase(&taskScheduler, &m_main->delay_partially_done());
         priority_queue_erase(&taskScheduler, &m_main->delay_partially_restarted());
-        priority_queue_insert(&taskScheduler, &m_main->delay_partially_done(), cachedTime);
+        priority_queue_upsert(&taskScheduler, &m_main->delay_partially_done(), cachedTime);
       }
     
       if (!m_main->have_queue()->empty() && m_main->have_queue()->front().first >= cachedTime)

--- a/libtorrent/src/protocol/handshake.cc
+++ b/libtorrent/src/protocol/handshake.cc
@@ -555,8 +555,7 @@ Handshake::read_peer() {
   manager->poll()->insert_write(this);
 
   // Give some extra time for reading/writing the bitfield.
-  priority_queue_erase(&taskScheduler, &m_taskTimeout);
-  priority_queue_insert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(120)).round_seconds());
+  priority_queue_upsert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(120)).round_seconds());
 
   return true;
 }

--- a/libtorrent/src/protocol/request_list.cc
+++ b/libtorrent/src/protocol/request_list.cc
@@ -183,16 +183,16 @@ void
 RequestList::unchoked() {
   m_last_unchoke = cachedTime;
 
-  priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
-
   // Clear choked queue if the peer doesn't start sending previously
   // requested pieces.
   //
   // This handles the case where a peer does a choke immediately
   // followed unchoke before starting to send pieces.
   if (!m_queues.queue_empty(bucket_choked)) {
-    priority_queue_insert(&taskScheduler, &m_delay_remove_choked,
+    priority_queue_upsert(&taskScheduler, &m_delay_remove_choked,
                           (cachedTime + rak::timer::from_seconds(timeout_remove_choked)).round_seconds());
+  } else {
+    priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
   }
 }
 
@@ -280,8 +280,7 @@ RequestList::downloading(const Piece& piece) {
 
     // We make sure that the choked queue eventually gets cleared if
     // the peer has skipped sending some pieces from the choked queue.
-    priority_queue_erase(&taskScheduler, &m_delay_remove_choked);
-    priority_queue_insert(&taskScheduler, &m_delay_remove_choked,
+    priority_queue_upsert(&taskScheduler, &m_delay_remove_choked,
                           (cachedTime + rak::timer::from_seconds(timeout_choked_received)).round_seconds());
     break;
   default:

--- a/libtorrent/src/torrent/tracker_controller.cc
+++ b/libtorrent/src/torrent/tracker_controller.cc
@@ -69,8 +69,7 @@ TrackerController::update_timeout(uint32_t seconds_to_next) {
   if (seconds_to_next != 0)
     next_timeout = (cachedTime + rak::timer::from_seconds(seconds_to_next)).round_seconds();
 
-  priority_queue_erase(&taskScheduler, &m_private->task_timeout);
-  priority_queue_insert(&taskScheduler, &m_private->task_timeout, next_timeout);
+  priority_queue_upsert(&taskScheduler, &m_private->task_timeout, next_timeout);
 }
 
 inline int
@@ -145,8 +144,7 @@ TrackerController::scrape_request(uint32_t seconds_to_request) {
   if (seconds_to_request != 0)
     next_timeout = (cachedTime + rak::timer::from_seconds(seconds_to_request)).round_seconds();
 
-  priority_queue_erase(&taskScheduler, &m_private->task_scrape);
-  priority_queue_insert(&taskScheduler, &m_private->task_scrape, next_timeout);
+  priority_queue_upsert(&taskScheduler, &m_private->task_scrape, next_timeout);
 }
 
 // The send_*_event() functions tries to ensure the relevant trackers

--- a/libtorrent/src/tracker/tracker_udp.cc
+++ b/libtorrent/src/tracker/tracker_udp.cc
@@ -274,8 +274,7 @@ TrackerUdp::event_read() {
 
     prepare_announce_input();
 
-    priority_queue_erase(&taskScheduler, &m_taskTimeout);
-    priority_queue_insert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(m_parent->info()->udp_timeout())).round_seconds());
+    priority_queue_upsert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(m_parent->info()->udp_timeout())).round_seconds());
 
     m_tries = m_parent->info()->udp_tries();
     manager->poll()->insert_write(this);


### PR DESCRIPTION
From @kannibalox
https://github.com/rakshasa/libtorrent/pull/248

The erase/insert pattern can be replaced by a single method that updates an existing entry's timer, or inserting if it doesn't exist.

This primary goal was to reduce CPU usage when handling incoming connections on large instances, but since the optimization was pretty generic it's been applied to many places.

Notes from stickz: This patch leads to higher throughput when seeding torrents. It greatly reduces the CPU usage of the rTorrent software. It is 100% stable and there are no downsides to using the patch. Tracker updates are also performed faster.