### PR TITLE
libtorrent: Add UDNS library for UDP trackers

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -6,9 +6,18 @@ SCRIPTDIR=$(dirname $(dirname "$SCRIPTPATH"))
 ROOTDIR=$(dirname "$SCRIPTDIR")
 
 # Set project build dirs
+UDNSDIR="$ROOTDIR/udns"
 XMLRPCDIR="$ROOTDIR/xmlrpc"
 LIBTORRENTDIR="$ROOTDIR/libtorrent"
 RTORRENTDIR="$ROOTDIR/rtorrent"
+
+# Install UDNS
+rm -fr "$UDNSDIR" && mkdir "$UDNSDIR" && cd "$UDNSDIR"
+git clone https://github.com/shadowsocks/libudns $UDNSDIR
+./autogen.sh
+./configure --prefix=/usr
+make -j$(nproc) CFLAGS="-O3 -fPIC"
+make -j$(nproc) install
 
 # Install xmlrp-c
 rm -fr "$XMLRPCDIR" && mkdir "$XMLRPCDIR" && cd "$XMLRPCDIR"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 ## Building
 This project does not offer pre-built binaries at this moment in time. It's required to build the project manually with xmlrpc-c. We test and develop our project with GCC and GNU Make.
 
+**Installing UDNS**
+We strongly advise to build rTorrent with UDNS for asynchronous DNS resolution of UDP trackers. This is an important stability change for the torrent client. Skip this step and use the development package from your Linux distribution if applicable.
+```
+git clone https://github.com/shadowsocks/libudns $UDNSDIR
+./autogen.sh
+./configure --prefix=/usr
+make -j$(nproc) CFLAGS="-O3 -fPIC"
+make -j$(nproc) install
+```
+
 **Installing xmlrpc-c**
 We strong advise that you use xmlrpc-c super stable branch to ensure the torrent client is stable.
 We recommend disabling c++, wininet and libwww support. And to use your curl installation.

--- a/libtorrent/scripts/udns.m4
+++ b/libtorrent/scripts/udns.m4
@@ -1,0 +1,26 @@
+# dnl function for enabling/disabling udns support
+AC_DEFUN([TORRENT_WITH_UDNS], [
+  AC_ARG_WITH(
+    [udns],
+    AS_HELP_STRING([--without-udns], [Don't use udns, falling back to synchronous DNS resolution.])
+  )
+  # dnl neither ubuntu nor fedora ships a pkgconfig file for udns
+  AS_IF(
+    [test "x$with_udns"  != "xno"],
+    [AC_CHECK_HEADERS([udns.h], [have_udns=yes], [have_udns=no])],
+    [have_udns=no]
+  )
+  AS_IF(
+    [test "x$have_udns" = "xyes"],
+    [
+      AC_DEFINE(USE_UDNS, 1, Define to build with udns support.)
+      LIBS="$LIBS -ludns"
+    ],
+    [
+      AS_IF(
+        [test "x$with_udns" = "xyes"],
+        [AC_MSG_ERROR([udns requested but not found])]
+      )
+    ]
+  )
+])

--- a/libtorrent/src/torrent/connection_manager.h
+++ b/libtorrent/src/torrent/connection_manager.h
@@ -40,6 +40,7 @@
 #define LIBTORRENT_CONNECTION_MANAGER_H
 
 #include <list>
+#include <memory>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
@@ -53,6 +54,30 @@ namespace torrent {
 // Standard pair of up/down throttles.
 // First element is upload throttle, second element is download throttle.
 typedef std::pair<Throttle*, Throttle*> ThrottlePair;
+
+// The sockaddr argument in the result call is NULL if the resolve failed,
+// and the int holds the error code.
+typedef std::function<void (const sockaddr*, int)> resolver_callback;
+
+// Encapsulates whether we do genuine async resolution or fall back to sync.
+// In a build with USE_UDNS, these do genuine asynchronous DNS resolution.
+// In a build without it, they're stubbed out to use a synchronous getaddrinfo(3)
+// call, while exposing the same API.
+class LIBTORRENT_EXPORT AsyncResolver {
+public:
+  AsyncResolver(ConnectionManager *);
+
+  // this queues a DNS resolve but doesn't send it. it doesn't execute any callbacks
+  // and returns control immediately. the return value is an opaque identifier that
+  // can be used to cancel the query (as long as the callback hasn't been executed yet):
+  virtual void*   enqueue(const char *name, int family, resolver_callback *cbck) = 0;
+  // this sends any queued resolves. it can execute arbitrary callbacks
+  // before returning control:
+  virtual void    flush() = 0;
+  // this cancels a pending async query (as long as the callback hasn't executed yet):
+  virtual void    cancel(void *query) = 0;
+};
+
 
 class LIBTORRENT_EXPORT ConnectionManager {
 public:
@@ -100,9 +125,7 @@ public:
   typedef std::function<uint32_t (const sockaddr*)>     slot_filter_type;
   typedef std::function<ThrottlePair (const sockaddr*)> slot_throttle_type;
 
-  // The sockaddr argument in the result slot call is NULL if the resolve failed, and the int holds the errno.
-  typedef std::function<void (const sockaddr*, int)> slot_resolver_result_type;
-  typedef std::function<slot_resolver_result_type* (const char*, int, int, slot_resolver_result_type)> slot_resolver_type;
+  typedef std::function<void (const char*, int, int, resolver_callback)> slot_resolver_type;
 
   ConnectionManager();
   ~ConnectionManager();
@@ -154,11 +177,15 @@ public:
   void                set_listen_port(port_type p)            { m_listen_port = p; }
   void                set_listen_backlog(int v);
 
-  // The resolver returns a pointer to its copy of the result slot
-  // which the caller may set blocked to prevent the slot from being
-  // called. The pointer must be NULL if the result slot was already
-  // called because the resolve was synchronous.
+  void*               enqueue_async_resolve(const char *name, int family, resolver_callback *cbck);
+  void                flush_async_resolves();
+  void                cancel_async_resolve(void *query);
+
+  // Legacy synchronous resolver interface.
   slot_resolver_type& resolver()          { return m_slot_resolver; }
+
+  // Asynchronous resolver interface.
+  AsyncResolver&      async_resolver()    { return *m_async_resolver; }
 
   // The slot returns a ThrottlePair to use for the given address, or
   // NULLs to use the default throttle.
@@ -190,6 +217,8 @@ private:
   slot_filter_type    m_slot_filter;
   slot_resolver_type  m_slot_resolver;
   slot_throttle_type  m_slot_address_throttle;
+
+  std::unique_ptr<AsyncResolver> m_async_resolver;
 };
 
 }

--- a/libtorrent/src/tracker/tracker_udp.h
+++ b/libtorrent/src/tracker/tracker_udp.h
@@ -56,8 +56,6 @@ public:
   typedef ProtocolBuffer<512> ReadBuffer;
   typedef ProtocolBuffer<512> WriteBuffer;
 
-  typedef ConnectionManager::slot_resolver_result_type resolver_type;
-
   static const uint64_t magic_connection_id = 0x0000041727101980ll;
 
   TrackerUdp(TrackerList* parent, rak::udp_tracker_info& info, int flags);
@@ -94,7 +92,6 @@ private:
   bool                process_error_output();
 
   bool                parse_udp_url(const std::string& url, hostname_type& hostname, int& port) const;
-  resolver_type*      make_resolver_slot(const char* hostname);
 
   rak::socket_address m_connectAddress;
   int                 m_port;
@@ -102,7 +99,8 @@ private:
 
   int                 m_sendState;
 
-  resolver_type*      m_slot_resolver;
+  resolver_callback   m_resolver_callback;
+  void*               m_resolver_query;
 
   uint32_t            m_action;
   uint64_t            m_connectionId;

--- a/libtorrent/src/utils/Makefile.am
+++ b/libtorrent/src/utils/Makefile.am
@@ -9,6 +9,8 @@ libsub_utils_la_SOURCES = \
 	sha1.h \
 	sha_fast.cc \
 	sha_fast.h \
-	queue_buckets.h
+	queue_buckets.h \
+	udnsevent.cc \
+	udnsevent.h
 
 AM_CPPFLAGS = -I$(srcdir) -I$(srcdir)/.. -I$(top_srcdir)

--- a/libtorrent/src/utils/udnsevent.cc
+++ b/libtorrent/src/utils/udnsevent.cc
@@ -1,0 +1,207 @@
+#include "config.h"
+#ifdef USE_UDNS
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <udns.h>
+
+#include <torrent/common.h>
+#include "udnsevent.h"
+#include "globals.h"
+#include "manager.h"
+#include "torrent/poll.h"
+
+namespace torrent {
+
+int udnserror_to_gaierror(int udnserror) {
+  switch (udnserror) {
+    case DNS_E_TEMPFAIL:
+      return EAI_AGAIN;
+    case DNS_E_PROTOCOL:
+      // this isn't quite right
+      return EAI_FAIL;
+    case DNS_E_NXDOMAIN:
+      return EAI_NONAME;
+    case DNS_E_NODATA:
+      return EAI_ADDRFAMILY;
+    case DNS_E_NOMEM:
+      return EAI_MEMORY;
+    case DNS_E_BADQUERY:
+      return EAI_NONAME;
+    default:
+      return EAI_ADDRFAMILY;
+  }
+}
+
+// Compatibility layers so udns can call std::function callbacks.
+
+void a4_callback_wrapper(struct ::dns_ctx *ctx, ::dns_rr_a4 *result, void *data) {
+  struct sockaddr_in sa;
+  udns_query *query = static_cast<udns_query*>(data);
+  // udns will free the a4_query after this callback exits
+  query->a4_query = NULL;
+
+  if (result == NULL || result->dnsa4_nrr == 0) {
+    if (query->a6_query == NULL) {
+      // nothing more to do: call the callback with a failure status
+      (*(query->callback))(NULL, udnserror_to_gaierror(::dns_status(ctx)));
+      delete query;
+    }
+    // else: return and wait to see if we get an a6 response
+  } else {
+    sa.sin_family = AF_INET;
+    sa.sin_port = 0;
+    sa.sin_addr = result->dnsa4_addr[0];
+    if (query->a6_query != NULL) {
+      ::dns_cancel(ctx, query->a6_query);
+    }
+    (*query->callback)(reinterpret_cast<sockaddr*>(&sa), 0);
+    delete query;
+  }
+}
+
+void a6_callback_wrapper(struct ::dns_ctx *ctx, ::dns_rr_a6 *result, void *data) {
+  struct sockaddr_in6 sa;
+  udns_query *query = static_cast<udns_query*>(data);
+  // udns will free the a6_query after this callback exits
+  query->a6_query = NULL;
+
+  if (result == NULL || result->dnsa6_nrr == 0) {
+    if (query->a4_query == NULL) {
+      // nothing more to do: call the callback with a failure status
+      (*(query->callback))(NULL, udnserror_to_gaierror(::dns_status(ctx)));
+      delete query;
+    }
+    // else: return and wait to see if we get an a6 response
+  } else {
+    sa.sin6_family = AF_INET6;
+    sa.sin6_port = 0;
+    sa.sin6_addr = result->dnsa6_addr[0];
+    if (query->a4_query != NULL) {
+      ::dns_cancel(ctx, query->a4_query);
+    }
+    (*query->callback)(reinterpret_cast<sockaddr*>(&sa), 0);
+    delete query;
+  }
+}
+
+
+UdnsEvent::UdnsEvent() {
+  // reinitialize the default context, no-op
+  // TODO don't do this here --- do it once in the manager, or in rtorrent
+  ::dns_init(NULL, 0);
+  // thread-safe context isolated to this object:
+  m_ctx = ::dns_new(NULL);
+  m_fileDesc = ::dns_open(m_ctx);
+  if (m_fileDesc == -1) throw internal_error("dns_init failed");
+
+  m_taskTimeout.slot() = std::bind(&UdnsEvent::process_timeouts, this);
+}
+
+UdnsEvent::~UdnsEvent() {
+  priority_queue_erase(&taskScheduler, &m_taskTimeout);
+  ::dns_close(m_ctx);
+  ::dns_free(m_ctx);
+  m_fileDesc = -1;
+
+  for (auto it = std::begin(m_malformed_queries); it != std::end(m_malformed_queries); ++it) {
+    delete *it;
+  }
+}
+
+void UdnsEvent::event_read() {
+  ::dns_ioevent(m_ctx, 0);
+}
+
+void UdnsEvent::event_write() {
+}
+
+void UdnsEvent::event_error() {
+}
+
+struct udns_query *UdnsEvent::enqueue_resolve(const char *name, int family, resolver_callback *callback) {
+  struct udns_query *query = new udns_query { NULL, NULL, callback, 0 };
+
+  if (family == AF_INET || family == AF_UNSPEC) {
+    query->a4_query = ::dns_submit_a4(m_ctx, name, 0, a4_callback_wrapper, query);
+    if (query->a4_query == NULL) {
+      // XXX udns does query parsing up front and will fail immediately
+      // during submission of malformed domain names, e.g., `..`. In order to
+      // maintain a clean interface, keep track of this query internally
+      // so we can call the callback later with a failure code
+      if (::dns_status(m_ctx) == DNS_E_BADQUERY) {
+        // this is what getaddrinfo(3) would return:
+        query->error = EAI_NONAME;
+        m_malformed_queries.push_back(query);
+        return query;
+      } else {
+        // unrecoverable errors, like ENOMEM
+        throw new internal_error("dns_submit_a4 failed");
+      }
+    }
+  }
+
+  if (family == AF_INET6) {
+    query->a6_query = ::dns_submit_a6(m_ctx, name, 0, a6_callback_wrapper, query);
+    if (query->a6_query == NULL) {
+      // it should be impossible for dns_submit_a6 to fail if dns_submit_a4
+      // succeeded, but just in case, make it a hard failure:
+      if (::dns_status(m_ctx) == DNS_E_BADQUERY && query->a4_query == NULL) {
+        query->error = EAI_NONAME;
+        m_malformed_queries.push_back(query);
+        return query;
+      } else {
+        throw new internal_error("dns_submit_a6 failed");
+      }
+    }
+  }
+
+  return query;
+}
+
+void UdnsEvent::flush_resolves() {
+  // first process any queries that were malformed
+  while (!m_malformed_queries.empty()) {
+    udns_query *query = m_malformed_queries.back();
+    m_malformed_queries.pop_back();
+    (*(query->callback))(NULL, query->error);
+    delete query;
+  }
+  process_timeouts();
+}
+
+void UdnsEvent::process_timeouts() {
+  int timeout = ::dns_timeouts(m_ctx, -1, 0);
+  if (timeout == -1) {
+    // no pending queries
+    manager->poll()->remove_read(this);
+    manager->poll()->remove_error(this);
+  } else {
+    manager->poll()->insert_read(this);
+    manager->poll()->insert_error(this);
+    priority_queue_upsert(&taskScheduler, &m_taskTimeout, (cachedTime + rak::timer::from_seconds(timeout)).round_seconds());
+  }
+}
+
+void UdnsEvent::cancel(struct udns_query *query) {
+  if (query == NULL) return;
+
+  if (query->a4_query != NULL) ::dns_cancel(m_ctx, query->a4_query);
+
+  if (query->a6_query != NULL) ::dns_cancel(m_ctx, query->a6_query);
+
+  auto it = std::find(std::begin(m_malformed_queries), std::end(m_malformed_queries), query);
+  if (it != std::end(m_malformed_queries)) m_malformed_queries.erase(it);
+
+  delete query;
+}
+
+const char *UdnsEvent::type_name() {
+  return "UdnsEvent";
+}
+
+}
+
+#endif

--- a/libtorrent/src/utils/udnsevent.h
+++ b/libtorrent/src/utils/udnsevent.h
@@ -1,0 +1,57 @@
+#ifndef LIBTORRENT_NET_UDNSEVENT_H
+#define LIBTORRENT_NET_UDNSEVENT_H
+
+#include lt_tr1_functional
+
+#include <list>
+#include <inttypes.h>
+
+#include <rak/priority_queue_default.h>
+#include "torrent/event.h"
+#include "torrent/connection_manager.h"
+
+struct dns_ctx;
+struct dns_query;
+
+namespace torrent {
+
+struct udns_query {
+    ::dns_query *a4_query;
+    ::dns_query *a6_query;
+    resolver_callback  *callback;
+    int                 error;
+};
+
+class UdnsEvent : public Event {
+public:
+
+  typedef std::vector<udns_query*> query_list_type;
+
+  UdnsEvent();
+  ~UdnsEvent();
+
+  virtual void        event_read();
+  virtual void        event_write();
+  virtual void        event_error();
+  virtual const char* type_name();
+
+  // wraps udns's dns_submit_a[46] functions. they and it return control immediately,
+  // without either sending outgoing UDP packets or executing callbacks:
+  udns_query*         enqueue_resolve(const char *name, int family, resolver_callback *callback);
+  // wraps the dns_timeouts function. it sends packets and can execute arbitrary
+  // callbacks:
+  void                flush_resolves();
+  // wraps the dns_cancel function:
+  void                cancel(udns_query *query);
+
+protected:
+  void                process_timeouts();
+
+  ::dns_ctx*             m_ctx;
+  rak::priority_item     m_taskTimeout;
+  query_list_type        m_malformed_queries;
+};
+
+}
+
+#endif


### PR DESCRIPTION
This commit adds UDNS support to libtorrent for asynchronous DNS resolution of UDP trackers. It is an important stability change to prevent a software failure, with a large number of torrents. The built in synchronous method is not stable.

There are few bugs with the UDNS implementation. There is a known issue where some trackers may not announce properly. However, this is medium severity compared to the critical severity issue of not being able to seed torrents.

UDNS has been reconfigured to work with upsert to process the time outs more efficiently. This results in significantly reduced CPU usage with a large number of UDP trackers, when processing timeouts. upsert is 100% stable with zero side effects.