### PR TITLE
Optimize code paths of load_session_torrents

### DIFF
--- a/libtorrent/src/dht/dht_hash_map.h
+++ b/libtorrent/src/dht/dht_hash_map.h
@@ -39,11 +39,7 @@
 
 #include "config.h"
 
-#if HAVE_TR1
-#include <lt_tr1_unordered_map>
-#else
-#include <map>
-#endif
+#include <unordered_map>
 
 #include "torrent/hash_string.h"
 
@@ -52,149 +48,58 @@
 
 namespace torrent {
 
-#if HAVE_TR1
-// Hash functions for HashString keys, and dereferencing HashString pointers.
-
-// Since the first few bits are very similar if not identical (since the IDs
-// will be close to our own node ID), we use an offset of 64 bits in the hash
-// string. These bits will be uniformly distributed until the number of DHT
-// nodes on the planet approaches 2^64 which is... unlikely.
-// An offset of 64 bits provides 96 significant bits which is fine as long as
-// the size of size_t does not exceed 12 bytes, while still having correctly
-// aligned 64-bit access.
-static const unsigned int hashstring_hash_ofs = 8;
-
-struct hashstring_ptr_hash : public std::unary_function<const HashString*, size_t> {
-  size_t operator () (const HashString* n) const {
-#if USE_ALIGNED
-    size_t result = 0;
-    const char *first = n->data() + hashstring_hash_ofs;
-    const char *last = first + sizeof(size_t);
-
-    while (first != last)
-      result = (result << 8) + *first++;
-    
-    return result;
-#else
-    return *(size_t*)(n->data() + hashstring_hash_ofs);
-#endif
-  }
-};
-
-struct hashstring_hash : public std::unary_function<HashString, size_t> {
-  size_t operator () (const HashString& n) const {
-#if USE_ALIGNED
-    size_t result = 0;
-    const char *first = n.data() + hashstring_hash_ofs;
-    const char *last = first + sizeof(size_t);
-
-    while (first != last)
-      result = (result << 8) + *first++;
-    
-    return result;
-#else
-    return *(size_t*)(n.data() + hashstring_hash_ofs);
-#endif
-  }
-};
-
-// Compare HashString pointers by dereferencing them.
-struct hashstring_ptr_equal : public std::binary_function<const HashString*, const HashString*, bool> {
-  size_t operator () (const HashString* one, const HashString* two) const 
-  { return *one == *two; }
-};
-
-class DhtNodeList : public std::unordered_map<const HashString*, DhtNode*, hashstring_ptr_hash, hashstring_ptr_equal> {
+class DhtNodeList : public std::unordered_map<const HashString*, DhtNode*> {
 public:
-  typedef std::unordered_map<const HashString*, DhtNode*, hashstring_ptr_hash, hashstring_ptr_equal> base_type;
+  using base_type = std::unordered_map<const HashString*, DhtNode*>;
 
   // Define accessor iterator with more convenient access to the key and
   // element values.  Allows changing the map definition more easily if needed.
   template<typename T>
   struct accessor_wrapper : public T {
-    accessor_wrapper(const T& itr) : T(itr) { }
+    accessor_wrapper(const T& itr)
+      : T(itr) {}
 
-    const HashString&    id() const    { return *(**this).first; }
-    DhtNode*             node() const  { return (**this).second; }
+    const HashString& id() const {
+      return *(**this).first;
+    }
+    DhtNode* node() const {
+      return (**this).second;
+    }
   };
 
-  typedef accessor_wrapper<const_iterator>  const_accessor;
-  typedef accessor_wrapper<iterator>        accessor;
+  using const_accessor = accessor_wrapper<const_iterator>;
+  using accessor       = accessor_wrapper<iterator>;
 
-  DhtNode*            add_node(DhtNode* n);
-
+  DhtNode* add_node(DhtNode* n);
 };
 
-class DhtTrackerList : public std::unordered_map<HashString, DhtTracker*, hashstring_hash> {
+class DhtTrackerList : public std::unordered_map<HashString, DhtTracker*> {
 public:
-  typedef std::unordered_map<HashString, DhtTracker*, hashstring_hash> base_type;
+  using base_type = std::unordered_map<HashString, DhtTracker*>;
 
   template<typename T>
   struct accessor_wrapper : public T {
-    accessor_wrapper(const T& itr) : T(itr) { }
+    accessor_wrapper(const T& itr)
+      : T(itr) {}
 
-    const HashString&    id() const       { return (**this).first; }
-    DhtTracker*          tracker() const  { return (**this).second; }
+    const HashString& id() const {
+      return (**this).first;
+    }
+    DhtTracker* tracker() const {
+      return (**this).second;
+    }
   };
 
-  typedef accessor_wrapper<const_iterator>  const_accessor;
-  typedef accessor_wrapper<iterator>        accessor;
-
+  using const_accessor = accessor_wrapper<const_iterator>;
+  using accessor       = accessor_wrapper<iterator>;
 };
 
-#else
-
-// Compare HashString pointers by dereferencing them.
-struct hashstring_ptr_less : public std::binary_function<const HashString*, const HashString*, bool> {
-  size_t operator () (const HashString* one, const HashString* two) const 
-  { return *one < *two; }
-};
-
-class DhtNodeList : public std::map<const HashString*, DhtNode*, hashstring_ptr_less> {
-public:
-  typedef std::map<const HashString*, DhtNode*, hashstring_ptr_less> base_type;
-
-  // Define accessor iterator with more convenient access to the key and
-  // element values.  Allows changing the map definition more easily if needed.
-  template<typename T>
-  struct accessor_wrapper : public T {
-    accessor_wrapper(const T& itr) : T(itr) { }
-
-    const HashString&    id() const    { return *(**this).first; }
-    DhtNode*             node() const  { return (**this).second; }
-  };
-
-  typedef accessor_wrapper<const_iterator>  const_accessor;
-  typedef accessor_wrapper<iterator>        accessor;
-
-  DhtNode*            add_node(DhtNode* n);
-
-};
-
-class DhtTrackerList : public std::map<HashString, DhtTracker*> {
-public:
-  typedef std::map<HashString, DhtTracker*> base_type;
-
-  template<typename T>
-  struct accessor_wrapper : public T {
-    accessor_wrapper(const T& itr) : T(itr) { }
-
-    const HashString&    id() const       { return (**this).first; }
-    DhtTracker*          tracker() const  { return (**this).second; }
-  };
-
-  typedef accessor_wrapper<const_iterator>  const_accessor;
-  typedef accessor_wrapper<iterator>        accessor;
-
-};
-#endif // HAVE_TR1
-
-inline
-DhtNode* DhtNodeList::add_node(DhtNode* n) {
+inline DhtNode*
+DhtNodeList::add_node(DhtNode* n) {
   insert(std::make_pair((const HashString*)n, (DhtNode*)n));
   return n;
 }
 
-}
+} // namespace torrent
 
 #endif

--- a/libtorrent/src/torrent/download/download_manager.cc
+++ b/libtorrent/src/torrent/download/download_manager.cc
@@ -50,15 +50,21 @@ DownloadManager::insert(DownloadWrapper* d) {
   if (find(d->info()->hash()) != end())
     throw internal_error("Could not add torrent as it already exists.");
 
+  lookup_cache.emplace(d->info()->hash(), size());
+  obfuscated_to_hash.emplace(d->info()->hash_obfuscated(), d->info()->hash());
+
   return base_type::insert(end(), d);
 }
 
 DownloadManager::iterator
 DownloadManager::erase(DownloadWrapper* d) {
-  iterator itr = std::find(begin(), end(), d);
+  auto itr = find(d->info()->hash());
 
   if (itr == end())
     throw internal_error("Tried to remove a torrent that doesn't exist");
+
+  lookup_cache.erase(lookup_cache.find(d->info()->hash()));
+  obfuscated_to_hash.erase(obfuscated_to_hash.find(d->info()->hash_obfuscated()));
     
   delete *itr;
   return base_type::erase(itr);
@@ -66,21 +72,36 @@ DownloadManager::erase(DownloadWrapper* d) {
 
 void
 DownloadManager::clear() {
-  while (!empty()) {
-    delete base_type::back();
-    base_type::pop_back();
-  }
+  base_type::clear();
+  lookup_cache.clear();
+  obfuscated_to_hash.clear();
 }
 
 DownloadManager::iterator
 DownloadManager::find(const std::string& hash) {
-  return std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                 rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  return find(*HashString::cast_from(hash));
 }
 
 DownloadManager::iterator
 DownloadManager::find(const HashString& hash) {
-  return std::find_if(begin(), end(), rak::equal(hash, rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  auto cached = lookup_cache.find(hash);
+
+  if (cached == lookup_cache.end()) {
+    return end();
+  }
+
+  auto cached_i = cached->second;
+
+  auto itr = cached_i < size() ? begin() + cached_i : end();
+  if (itr == end() || (*itr)->info()->hash() != hash) {
+    itr = std::find_if(begin(), end(), [hash](DownloadWrapper* wrapper) {
+      return hash == wrapper->info()->hash();
+    });
+  }
+
+  lookup_cache[hash] = itr - begin();
+
+  return itr;
 }
 
 DownloadManager::iterator
@@ -95,24 +116,30 @@ DownloadManager::find_chunk_list(ChunkList* cl) {
 
 DownloadMain*
 DownloadManager::find_main(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash))));
+  auto itr = find(*HashString::cast_from(hash));
 
-  if (itr == end())
-    return NULL;
-  else
-    return (*itr)->main();
+  if (itr == end()) {
+    return nullptr;
+  }
+
+  return (*itr)->main();
 }
 
 DownloadMain*
-DownloadManager::find_main_obfuscated(const char* hash) {
-  iterator itr = std::find_if(begin(), end(), rak::equal(*HashString::cast_from(hash),
-                                                         rak::on(std::mem_fun(&DownloadWrapper::info), std::mem_fun(&DownloadInfo::hash_obfuscated))));
+DownloadManager::find_main_obfuscated(const char* obfuscated) {
+  auto hash_itr = obfuscated_to_hash.find(*HashString::cast_from(obfuscated));
 
-  if (itr == end())
-    return NULL;
-  else
-    return (*itr)->main();
+  if (hash_itr == obfuscated_to_hash.end()) {
+    return nullptr;
+  }
+
+  auto itr = find(hash_itr->second);
+
+  if (itr == end()) {
+    return nullptr;
+  }
+
+  return (*itr)->main();
 }
 
 }

--- a/libtorrent/src/torrent/download/download_manager.h
+++ b/libtorrent/src/torrent/download/download_manager.h
@@ -37,8 +37,10 @@
 #ifndef LIBTORRENT_DOWNLOAD_MANAGER_H
 #define LIBTORRENT_DOWNLOAD_MANAGER_H
 
+#include <unordered_map>
 #include <vector>
 #include <torrent/common.h>
+#include <torrent/hash_string.h>
 
 namespace torrent {
 
@@ -90,6 +92,10 @@ public:
   iterator            erase(DownloadWrapper* d) LIBTORRENT_NO_EXPORT;
 
   void                clear() LIBTORRENT_NO_EXPORT;
+  
+private:
+  std::unordered_map<HashString, size_type>  lookup_cache;
+  std::unordered_map<HashString, HashString> obfuscated_to_hash;
 };
 
 }

--- a/libtorrent/src/torrent/hash_string.h
+++ b/libtorrent/src/torrent/hash_string.h
@@ -60,8 +60,17 @@ public:
   typedef std::reverse_iterator<const_iterator>   const_reverse_iterator;
 
   static const size_type size_data = 20;
+  
+  static constexpr unsigned int hashstring_hash_ofs = 8;
+  static_assert((hashstring_hash_ofs + sizeof(size_t)) <= HashString::size_data);
 
   size_type           size() const                      { return size_data; }
+  
+  size_t hash() const {
+    size_t result = 0;
+    std::memcpy(&result, m_data + torrent::HashString::hashstring_hash_ofs, sizeof(size_t));
+    return result;
+  }
 
   iterator            begin()                           { return m_data; }
   const_iterator      begin() const                     { return m_data; }
@@ -129,6 +138,32 @@ inline bool
 operator <= (const HashString& one, const HashString& two) {
   return std::memcmp(one.begin(), two.begin(), HashString::size_data) <= 0;
 }
+
+}
+
+namespace std {
+
+template<>
+struct hash<torrent::HashString> {
+  std::size_t operator()(const torrent::HashString& n) const noexcept {
+    return n.hash();
+  }
+};
+
+template<>
+struct hash<torrent::HashString*> {
+  std::size_t operator()(const torrent::HashString* n) const noexcept {
+    return n->hash();
+  }
+};
+
+template<>
+struct equal_to<torrent::HashString*> {
+  bool operator()(const torrent::HashString* a,
+                  const torrent::HashString* b) const noexcept {
+    return *a == *b;
+  }
+};
 
 }
 

--- a/rtorrent/src/control.cc
+++ b/rtorrent/src/control.cc
@@ -114,8 +114,6 @@ Control::initialize() {
   m_core->listen_open();
   m_core->download_store()->enable(rpc::call_command_value("session.use_lock"));
 
-  m_core->set_hashing_view(*m_viewManager->find_throw("hashing"));
-
   m_ui->init(this);
 
   if(!display::Canvas::daemon()) {

--- a/rtorrent/src/core/download_factory.cc
+++ b/rtorrent/src/core/download_factory.cc
@@ -41,7 +41,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <rak/path.h>
-#include lt_tr1_functional
 #include <torrent/utils/log.h>
 #include <torrent/utils/resume.h>
 #include <torrent/object.h>
@@ -106,7 +105,8 @@ DownloadFactory::DownloadFactory(Manager* m) :
   m_start(false),
   m_printLog(true),
   m_isFile(false),
-  m_initLoad(false) {
+  m_initLoad(false),
+  m_immediate(false){
 
   m_taskLoad.slot() = std::bind(&DownloadFactory::receive_load, this);
   m_taskCommit.slot() = std::bind(&DownloadFactory::receive_commit, this);
@@ -132,6 +132,10 @@ void
 DownloadFactory::load(const std::string& uri) {
   m_uri = uri;
   priority_queue_insert(&taskScheduler, &m_taskLoad, cachedTime);
+  
+  if (m_immediate) {
+    priority_queue_perform(&taskScheduler, cachedTime);
+  }
 }
 
 // This function must be called before DownloadFactory::commit().
@@ -147,6 +151,10 @@ DownloadFactory::load_raw_data(const std::string& input) {
 void
 DownloadFactory::commit() {
   priority_queue_insert(&taskScheduler, &m_taskCommit, cachedTime);
+  
+  if (m_immediate) {
+    priority_queue_perform(&taskScheduler, cachedTime);
+  }
 }
 
 void
@@ -204,6 +212,10 @@ DownloadFactory::receive_commit() {
 
   if (m_loaded)
     receive_success();
+  else {
+    // drop immediate as this is asynchronous.
+    m_immediate = false;  
+  }
 }
 
 void
@@ -323,11 +335,13 @@ DownloadFactory::receive_success() {
     std::for_each(m_commands.begin(), m_commands.end(),
                   rak::bind2nd(std::ptr_fun(&rpc::parse_command_multiple_std), rpc::make_target(download)));
 
-    if (m_manager->download_list()->find(infohash) == m_manager->download_list()->end())
-      throw torrent::input_error("The newly created download was removed.");
+    if (!m_session) {
+      if (m_manager->download_list()->find(infohash) == m_manager->download_list()->end()) {
+        throw torrent::input_error("The newly created download was removed.");
+      }
 
-    if (!m_session)
-       rpc::call_command("d.state.set", (int64_t)m_start, rpc::make_target(download));
+      rpc::call_command("d.state.set", (int64_t)m_start, rpc::make_target(download));
+    }
 
     rpc::commands.call_catch(m_session ? "event.download.inserted_session" : "event.download.inserted_new",
                              rpc::make_target(download), torrent::Object(), "Download event action failed: ");
@@ -345,7 +359,7 @@ DownloadFactory::receive_success() {
       //     m_manager->download_list()->erase(m_manager->download_list()->find(infohash.data()));
     }
   }
-
+  
   m_slot_finished();
 }
 
@@ -377,11 +391,17 @@ DownloadFactory::log_created(Download* download, torrent::Object* rtorrent) {
 
 void
 DownloadFactory::receive_failed(const std::string& msg) {
+  bool shouldThrow = m_immediate;
+  
   // Add message to log.
   if (m_printLog)
     m_manager->push_log_std(msg + ": \"" + m_uri + "\"");
 
   m_slot_finished();
+  
+  if (shouldThrow) {
+    throw torrent::input_error(msg);
+  }
 }
 
 void

--- a/rtorrent/src/core/download_factory.h
+++ b/rtorrent/src/core/download_factory.h
@@ -79,6 +79,9 @@ public:
   
   bool                get_init_load() const { return m_initLoad; }
   void                set_init_load(bool v) { m_initLoad = v; }
+  
+  bool                get_immediate() const { return m_immediate; }
+  void                set_immediate(bool v) { m_immediate = v; }
 
   bool                print_log() const     { return m_printLog; }
   void                set_print_log(bool v) { m_printLog = v; }
@@ -109,7 +112,8 @@ private:
   bool                m_printLog;
   bool                m_isFile;
   bool                m_initLoad;
-
+  bool                m_immediate;
+  
   command_list_type         m_commands;
   torrent::Object::map_type m_variables;
 

--- a/rtorrent/src/core/manager.h
+++ b/rtorrent/src/core/manager.h
@@ -122,6 +122,7 @@ public:
   static const int create_tied     = 0x2;
   static const int create_quiet    = 0x4;
   static const int create_raw_data = 0x8;
+  static const int create_throw    = 0x16;
 
   typedef std::vector<std::string> command_list_type;
 

--- a/rtorrent/src/core/view.cc
+++ b/rtorrent/src/core/view.cc
@@ -251,6 +251,10 @@ View::prev_focus() {
 
 void
 View::sort() {
+  if (m_sortCurrent.is_empty()) {
+    return;
+  }
+  
   Download* curFocus = focus() != end_visible() ? *focus() : NULL;
 
   // Don't go randomly switching around equivalent elements.
@@ -312,7 +316,11 @@ View::filter_by(const torrent::Object& condition, View::base_type& result) {
 
 void
 View::filter_download(core::Download* download) {
-  iterator itr = std::find(base_type::begin(), base_type::end(), download);
+  iterator itr = std::find(base_type::end() - 1, base_type::end(), download);
+  
+  if (itr == base_type::end()) {
+    itr = std::find(base_type::begin(), base_type::end() - 1, download);
+  }
 
   if (itr == base_type::end())
     throw torrent::internal_error("View::filter_download(...) could not find download.");
@@ -358,7 +366,10 @@ View::clear_filter_on() {
 
 inline void
 View::insert_visible(Download* d) {
-  iterator itr = std::find_if(begin_visible(), end_visible(), std::bind1st(view_downloads_compare(m_sortNew), d));
+  iterator itr = m_sortNew.is_empty() ? end_visible() :
+    std::find_if(begin_visible(), end_visible(), [d, this](Download* download) {
+      return view_downloads_compare(m_sortNew)(d, download);
+    });
 
   m_size++;
   m_focus += (m_focus >= position(itr));

--- a/rtorrent/src/main.cc
+++ b/rtorrent/src/main.cc
@@ -62,6 +62,7 @@
 #include "core/download_factory.h"
 #include "core/download_store.h"
 #include "core/manager.h"
+#include "core/view_manager.h"
 #include "display/canvas.h"
 #include "display/window.h"
 #include "display/manager.h"
@@ -133,10 +134,17 @@ load_session_torrents() {
     // Replace with session torrent flag.
     f->set_session(true);
     f->set_init_load(true);
+    f->set_immediate(true);
     f->slot_finished(std::bind(&rak::call_delete_func<core::DownloadFactory>, f));
     f->load(entries.path() + first->d_name);
     f->commit();
   }
+  
+  const auto& hashing_view = *control->view_manager()->find_throw("hashing");
+  control->core()->set_hashing_view(hashing_view);
+  hashing_view->set_focus(hashing_view->focus());
+  
+  rak::priority_queue_perform(&taskScheduler, cachedTime);  
 }
 
 void
@@ -310,8 +318,6 @@ main(int argc, char** argv) {
        "view.add = default\n"
 
        "view.add = name\n"
-       "view.sort_new     = name,((less,((d.name))))\n"
-       "view.sort_current = name,((less,((d.name))))\n"
 
        "view.add = active\n"
        "view.filter = active,((false))\n"
@@ -349,15 +355,25 @@ main(int argc, char** argv) {
        "view.filter = leeching,((and,((d.state)),((not,((d.complete))))))\n"
        "view.filter_on = leeching,event.download.resumed,event.download.paused,event.download.finished\n"
 
-       "schedule2 = view.main,10,10,((view.sort,main,20))\n"
-       "schedule2 = view.name,10,10,((view.sort,name,20))\n"
-
        "schedule2 = session_save,1200,1200,((session.save))\n"
        "schedule2 = low_diskspace,5,60,((close_low_diskspace,500M))\n"
        "schedule2 = prune_file_status,3600,86400,((system.file_status_cache.prune))\n"
 
        "protocol.encryption.set=allow_incoming,prefer_plaintext,enable_retry\n"
     );
+	
+	// Sorting is O(n*log(n)) and very expensive
+    // RPC user does not rely on rTorrent for sorted list
+    // Only set view sorting and periodic resorting when not in daemon mode
+    if (!rpc::call_command_value("system.daemon")) {
+      rpc::parse_command_multiple(
+        rpc::make_target(),
+        "view.sort_new     = name,((less,((d.name))))\n"
+        "view.sort_current = name,((less,((d.name))))\n"
+
+        "schedule2 = view.main,10,10,((view.sort,main,20))\n"
+        "schedule2 = view.name,10,10,((view.sort,name,20))\n");
+    }
 
     // Functions that might not get depracted as they are nice for
     // configuration files, and thus might do with just some


### PR DESCRIPTION
rTorrent changes from jesec
https://github.com/jesec/rtorrent/pull/37

```
main: batch checking after the whole session loaded
"receive_hashing_changed" is an O(n) operation, where n is the
number of entities in the download list. It is not efficient when
the function is triggered every time a torrent has been inserted
by "load_session_torrents", making the whole operation O(n^2).

Thus, delay checking until the whole session has been loaded.
```
```
view: add a fast path for newly added element

filter_download is often called after a new element is added.

Since new elements are always inserted to the back, it is more
efficient to check the last element first, so we have O(1) instead
of O(n) in this common case.
```
```
view: insert directly if sorting is not required
O(n) -> O(1)
```

```
main: only set view sorting and periodic resorting when not in daemon mode

Sorting is O(n*log(n)) and very expensive. RPC user (such as Flood
or ruTorrent) does not rely on rTorrent for sorted list.
```
```
download_factory: don't check for "removed-right-after-add" when loading session

As no command is attached when loading from session, it is
impossible for this edge case to occur.

"find" on the download list, a "std::list" linked list, is
an O(n) operation. With it, the session loading is O(n^2),
where n is the number of entities in the session directory.

As such, remove this unnecessary check to speed things up.
```
```
main: bypass queuing in "load_session_torrents"

It is more expensive to queue all the items and then dequeue and
process them one by one, due to O(n*log(n)) time complexity of
"priority_queue", where n is the number of tasks already in the
queue, and memory reallocation.

We do not need task queuing in the synchronous loading of session.
After all, we called "priority_queue_perform" right after queuing.

As such, call "f->set_immediate(true)", so at any time the queue
has at most 1 task, which speeds up session loading.
```

libtorrent changes from: jesec
https://github.com/jesec/libtorrent/pull/5

```
download_manager: implement a lookup cache to speedup common cases

For most calls, the download list will be exactly the same as the
previous call. As such, implement a hashmap-based cache to speed
up this common case to O(1) lookup.
```