### PR TITLE
rTorrent: Resolve LTO build issues

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -31,14 +31,14 @@ make -j$(nproc) install
 cd "$LIBTORRENTDIR"
 ./autogen.sh
 ./configure --prefix=/usr --enable-aligned
-make -j$(nproc) CXXFLAGS="-O3" all
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing" all
 make -j$(nproc) install
 
 #install rtorrent
 cd "$RTORRENTDIR"
 ./autogen.sh
 ./configure --prefix=/usr --with-xmlrpc-c
-make -j$(nproc) CXXFLAGS="-O3" all
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing" all
 make -j$(nproc) install
 
 #rebuild script 21

--- a/.github/scripts/build_whatbox.sh
+++ b/.github/scripts/build_whatbox.sh
@@ -13,14 +13,14 @@ RTORRENTDIR="$ROOTDIR/rtorrent"
 cd "$LIBTORRENTDIR"
 ./autogen.sh
 ./configure --prefix="$ROOTDIR" --enable-aligned
-make -j$(nproc) CXXFLAGS="-O3"
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
 make -j$(nproc) install
 
 #install rtorrent
 cd "$RTORRENTDIR"
 ./autogen.sh
 ./configure --prefix="$ROOTDIR" --with-xmlrpc-c
-make -j$(nproc) CXXFLAGS="-O3 -I$ROOTDIR/include" LDFLAGS="-L$ROOTDIR/lib -ltorrent"
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing -I$ROOTDIR/include" LDFLAGS="-L$ROOTDIR/lib -ltorrent"
 make -j$(nproc) install
 
 #rebuild script 21

--- a/README.md
+++ b/README.md
@@ -43,6 +43,28 @@ make -j$(nproc) CXXFLAGS="-O3"
 make install
 ```
 
+## Building with LTO
+This project supports building libtorrent and rTorrent with LTO (Link Time Optimizations). This support is still at the experimental stage. Please file an issue report if the build fails and disable LTO. We mark some warnings as errors, to ensure compatibility. It's imperative not to bypass these.
+
+### Installing libtorrent
+We strongly advise to configure with aligned memory access to avoid critical stability issues.
+```
+cd libtorrent
+./autogen.sh
+./configure --prefix=/usr --enable-aligned
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+make install
+```
+
+### Installing rTorrent
+We strongly advise to configure with xmlrpc-c to ensure ruTorrent is supported.
+```
+cd rtorrent
+./autogen.sh
+./configure --prefix=/usr --with-xmlrpc-c
+make -j$(nproc) CXXFLAGS="-O3 -flto=\"$(nproc)\" -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+make install
+
 ## Configuring
 Please take a minute to review the custom **.rtorrent.rc** file. This project has specific requirements for configuration.
 

--- a/rtorrent/src/core/download_store.cc
+++ b/rtorrent/src/core/download_store.cc
@@ -193,7 +193,7 @@ DownloadStore::remove(Download* d) {
 // This also needs to check that it isn't a directory.
 bool
 not_correct_format(const utils::directory_entry& entry) {
-  return !DownloadStore::is_correct_format(entry.d_name);
+  return !DownloadStore::is_correct_format(entry.s_name);
 }
 
 utils::Directory

--- a/rtorrent/src/core/manager.cc
+++ b/rtorrent/src/core/manager.cc
@@ -378,7 +378,7 @@ Manager::try_create_download_from_meta_download(torrent::Object* bencode, const 
 
 utils::Directory
 path_expand_transform(std::string path, const utils::directory_entry& entry) {
-  return path + entry.d_name;
+  return path + entry.s_name;
 }
 
 // Move this somewhere better.
@@ -418,7 +418,7 @@ path_expand(std::vector<std::string>* paths, const std::string& pattern) {
       // Only include filenames starting with '.' if the pattern
       // starts with the same.
       itr->update((r.pattern()[0] != '.') ? utils::Directory::update_hide_dot : 0);
-      itr->erase(std::remove_if(itr->begin(), itr->end(), rak::on(rak::mem_ref(&utils::directory_entry::d_name), std::not1(r))), itr->end());
+      itr->erase(std::remove_if(itr->begin(), itr->end(), rak::on(rak::mem_ref(&utils::directory_entry::s_name), std::not1(r))), itr->end());
 
       std::transform(itr->begin(), itr->end(), std::back_inserter(nextCache), rak::bind1st(std::ptr_fun(&path_expand_transform), itr->path() + (itr->path() == "/" ? "" : "/")));
     }

--- a/rtorrent/src/input/path_input.cc
+++ b/rtorrent/src/input/path_input.cc
@@ -76,11 +76,11 @@ PathInput::pressed(int key) {
 struct _transform_filename {
   void operator () (utils::directory_entry& entry) {
 #ifdef __sun__
-    if (entry.d_type & S_IFDIR)
+    if (entry.s_type & S_IFDIR)
 #else
-    if (entry.d_type == DT_DIR)
+    if (entry.s_type == DT_DIR)
 #endif
-      entry.d_name += '/';
+      entry.s_name += '/';
   }
 };
 
@@ -105,7 +105,7 @@ PathInput::receive_do_complete() {
   if (r.first == r.second)
     return; // Show some nice colors here.
 
-  std::string base = rak::make_base<std::string>(r.first, r.second, rak::const_mem_ref(&utils::directory_entry::d_name));
+  std::string base = rak::make_base<std::string>(r.first, r.second, rak::const_mem_ref(&utils::directory_entry::s_name));
 
   // Clear the path after the cursor to make this code cleaner. It's
   // not really nessesary to add the complexity just because someone
@@ -142,12 +142,12 @@ PathInput::find_last_delim() {
 
 inline bool
 find_complete_compare(const utils::directory_entry& complete, const std::string& base) {
-  return complete.d_name.compare(0, base.size(), base);
+  return complete.s_name.compare(0, base.size(), base);
 }
 
 inline bool
 find_complete_not_compare(const utils::directory_entry& complete, const std::string& base) {
-  return !complete.d_name.compare(0, base.size(), base);
+  return !complete.s_name.compare(0, base.size(), base);
 }
 
 PathInput::range_type

--- a/rtorrent/src/main.cc
+++ b/rtorrent/src/main.cc
@@ -136,7 +136,7 @@ load_session_torrents() {
     f->set_init_load(true);
     f->set_immediate(true);
     f->slot_finished(std::bind(&rak::call_delete_func<core::DownloadFactory>, f));
-    f->load(entries.path() + first->d_name);
+    f->load(entries.path() + first->s_name);
     f->commit();
   }
   

--- a/rtorrent/src/ui/element_string_list.h
+++ b/rtorrent/src/ui/element_string_list.h
@@ -86,7 +86,7 @@ public:
     m_list.clear();
 
     while (first != last)
-      m_list.push_back((first++)->d_name);
+      m_list.push_back((first++)->s_name);
 
     if (m_window != NULL) {
       lt_log_print(torrent::LOG_UI_EVENTS, "element_string_list: set dirent range (visible)");

--- a/rtorrent/src/utils/directory.cc
+++ b/rtorrent/src/utils/directory.cc
@@ -83,19 +83,19 @@ Directory::update(int flags) {
 
 #ifdef __sun__
     stat(entry->d_name, &s);
-    itr->d_fileno = entry->d_ino;
-    itr->d_reclen = 0;
-    itr->d_type = s.st_mode;
+    itr->s_fileno = entry->d_ino;
+    itr->s_reclen = 0;
+    itr->s_type = s.st_mode;
 #else
-    itr->d_fileno = entry->d_fileno;
-    itr->d_reclen = entry->d_reclen;
-    itr->d_type   = entry->d_type;
+    itr->s_fileno = entry->d_fileno;
+    itr->s_reclen = entry->d_reclen;
+    itr->s_type   = entry->d_type;
 #endif
 
 #ifdef DIRENT_NAMLEN_EXISTS_FOOBAR
-    itr->d_name   = std::string(entry->d_name, entry->d_name + entry->d_namlen);
+    itr->s_name   = std::string(entry->d_name, entry->d_name + entry->d_namlen);
 #else
-    itr->d_name   = std::string(entry->d_name);
+    itr->s_name   = std::string(entry->d_name);
 #endif
   }
 

--- a/rtorrent/src/utils/directory.h
+++ b/rtorrent/src/utils/directory.h
@@ -48,11 +48,11 @@ struct directory_entry {
   bool is_file() const { return true; }
 
   // The name and types should match POSIX.
-  uint32_t            d_fileno;
-  uint32_t            d_reclen; //Not used. Messes with Solaris.
-  uint8_t             d_type;
+  uint32_t            s_fileno;
+  uint32_t            s_reclen; //Not used. Messes with Solaris.
+  uint8_t             s_type;
 
-  std::string         d_name;
+  std::string         s_name;
 };
 
 class Directory : private std::vector<directory_entry> {
@@ -94,12 +94,12 @@ private:
   std::string         m_path;
 };
 
-inline bool operator == (const directory_entry& left, const directory_entry& right) { return left.d_name == right.d_name; }
-inline bool operator != (const directory_entry& left, const directory_entry& right) { return left.d_name != right.d_name; }
-inline bool operator <  (const directory_entry& left, const directory_entry& right) { return left.d_name <  right.d_name; }
-inline bool operator >  (const directory_entry& left, const directory_entry& right) { return left.d_name >  right.d_name; }
-inline bool operator <= (const directory_entry& left, const directory_entry& right) { return left.d_name <= right.d_name; }
-inline bool operator >= (const directory_entry& left, const directory_entry& right) { return left.d_name >= right.d_name; }
+inline bool operator == (const directory_entry& left, const directory_entry& right) { return left.s_name == right.s_name; }
+inline bool operator != (const directory_entry& left, const directory_entry& right) { return left.s_name != right.s_name; }
+inline bool operator <  (const directory_entry& left, const directory_entry& right) { return left.s_name <  right.s_name; }
+inline bool operator >  (const directory_entry& left, const directory_entry& right) { return left.s_name >  right.s_name; }
+inline bool operator <= (const directory_entry& left, const directory_entry& right) { return left.s_name <= right.s_name; }
+inline bool operator >= (const directory_entry& left, const directory_entry& right) { return left.s_name >= right.s_name; }
 
 }
 


### PR DESCRIPTION
- Resolve an ODR conflict with rTorrent when building with LTO.
- Enable LTO for builds and mark some warnings as errors.
- Update readme for documentation purposes.